### PR TITLE
Remove intermediate zip file from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ FROM base-$TARGETARCH
 RUN apt-get update  \
     && apt-get install -y curl unzip \
     && curl -L -o duckdb_cli.zip "https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/duckdb_cli-linux-${DUCKDB_ARCH}.zip" \
-    && unzip duckdb_cli.zip
+    && unzip duckdb_cli.zip \
+    && rm duckdb_cli.zip
 
 ENTRYPOINT [ "./duckdb" ]


### PR DESCRIPTION
Zip file is 15MB and is not needed in the final image.