### PR TITLE
Use absolute path for entry point, so that working directory can be changed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN apt-get update  \
     && curl -L -o duckdb_cli.zip "https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/duckdb_cli-linux-${DUCKDB_ARCH}.zip" \
     && unzip duckdb_cli.zip
 
-ENTRYPOINT [ "./duckdb" ]
+ENTRYPOINT [ "/duckdb" ]


### PR DESCRIPTION
This allows easily mounting a local directory:

```
docker run -it -v "$PWD:$PWD" -w "$PWD" datacatering/duckdb:v1.1.0 "${@}"
```